### PR TITLE
Support site_root_url placeholder in "default" preview client url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,17 @@ Run migrations:
 $ ./manage.py migrate
 ```
 
-then configure the preview client URL using the `HEADLESS_PREVIEW_CLIENT_URLS` setting.
+Then configure the preview client URL using the `HEADLESS_PREVIEW_CLIENT_URLS` setting:
 
-For single site, the configuration should look like:
+```python
+HEADLESS_PREVIEW_CLIENT_URLS = {
+    'default': '{site_root_url}/',
+}
+```
+
+The `{site_root_url}` placeholder is replaced with the `root_url` of the `Site` the preview page belongs to.
+
+If the Wagtail `Site` object isn't configured with the frontend domain it is possible to hardcode an url:
 
 ```python
 HEADLESS_PREVIEW_CLIENT_URLS = {

--- a/wagtail_headless_preview/models.py
+++ b/wagtail_headless_preview/models.py
@@ -65,10 +65,13 @@ class HeadlessPreviewMixin:
         )
 
     def get_client_root_url(self):
+        site = self.get_site()
         try:
-            return settings.HEADLESS_PREVIEW_CLIENT_URLS[self.get_site().hostname]
+            return settings.HEADLESS_PREVIEW_CLIENT_URLS[site.hostname]
         except (AttributeError, KeyError):
-            return settings.HEADLESS_PREVIEW_CLIENT_URLS["default"]
+            return settings.HEADLESS_PREVIEW_CLIENT_URLS["default"].format(
+                site_root_url=site.root_url
+            )
 
     @classmethod
     def get_content_type_str(cls):


### PR DESCRIPTION
Fixes #16

I got stuck on updating the docs. Hope it's clear enough/acceptable