### PR TITLE
Change to unified settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,18 @@ $ pre-commit install
 $ pre-commit run --all-files
 ```
 
+### How to run tests
+
+Now you can run tests as shown below:
+
+```sh
+tox -p
+```
+
+or, you can run them for a specific environment `tox -e py39-django3.2-wagtail2.15` or specific test
+`tox -e py310-django3.2-wagtail2.15 wagtail_headless_preview.tests.test_frontend.TestFrontendViews.test_redirect_on_preview`
+
 ## Credits
 
 - Matthew Westcott ([@gasman](https://github.com/gasman)), initial proof of concept
-- Karl Hobley ([@kaedroho](https://github.com/kaedroho)), improvements
+- Karl Hobley ([@kaedroho](https://github.com/kaedroho)), PoC improvements

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
 
 install_command = pip install -U {opts} {packages}
 commands =
-    coverage run runtests.py
+    coverage run runtests.py {posargs: -v 2}
     coverage report -m
 
 [testenv:interactive]

--- a/wagtail_headless_preview/deprecation.py
+++ b/wagtail_headless_preview/deprecation.py
@@ -1,0 +1,6 @@
+class RemovedInWagtailHeadlessPreivew030Warning(PendingDeprecationWarning):
+    pass
+
+
+class RemovedInWagtailHeadlessPreivew040Warning(DeprecationWarning):
+    pass

--- a/wagtail_headless_preview/models.py
+++ b/wagtail_headless_preview/models.py
@@ -1,12 +1,13 @@
 import datetime
 import json
 
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.signing import TimestampSigner
 from django.db import models
 from django.shortcuts import redirect, render
 from django.utils.http import urlencode
+
+from wagtail_headless_preview.settings import headless_preview_settings
 
 
 class PagePreview(models.Model):
@@ -34,9 +35,9 @@ class PagePreview(models.Model):
 
 def get_client_root_url_from_site(site):
     try:
-        root_url = settings.HEADLESS_PREVIEW_CLIENT_URLS[site.hostname]
+        root_url = headless_preview_settings.CLIENT_URLS[site.hostname]
     except (AttributeError, KeyError):
-        root_url = settings.HEADLESS_PREVIEW_CLIENT_URLS["default"].format(
+        root_url = headless_preview_settings.CLIENT_URLS["default"].format(
             SITE_ROOT_URL=site.root_url
         )
 
@@ -118,7 +119,7 @@ class HeadlessPreviewMixin:
         response_token = token or page_preview.token
         preview_url = self.get_preview_url(response_token)
 
-        if getattr(settings, "HEADLESS_PREVIEW_REDIRECT", False):
+        if headless_preview_settings.REDIRECT_ON_PREVIEW:
             return redirect(preview_url)
 
         response = render(
@@ -157,8 +158,8 @@ class HeadlessServeMixin:
         By default this uses the hosts defined in HEADLESS_PREVIEW_CLIENT_URLS.
         However, you can enforce a single host using  the HEADLESS_SERVE_BASE_URL setting.
         """
-        if getattr(settings, "HEADLESS_SERVE_BASE_URL", None):
-            base_url = settings.HEADLESS_SERVE_BASE_URL
+        if headless_preview_settings.SERVE_BASE_URL:
+            base_url = headless_preview_settings.SERVE_BASE_URL
         else:
             base_url = get_client_root_url_from_site(self.get_site())
         site_id, site_root, relative_page_url = self.get_url_parts(request)

--- a/wagtail_headless_preview/settings.py
+++ b/wagtail_headless_preview/settings.py
@@ -1,0 +1,126 @@
+"""
+The wagtail_headless_preview settings are namespaced in the WAGTAIL_HEADLESS_PREVIEW setting.
+For example your project's `settings.py` file might look like this:
+WAGTAIL_HEADLESS_PREVIEW = {
+    "CLIENT_URLS": {"default": "https://headless.site"},
+    # ...
+}
+This module provides the `headless_preview_settings` object, that is used to access
+the settings. It checks for user settings first, with fallback to defaults.
+"""
+import warnings
+
+from django.conf import settings
+from django.test.signals import setting_changed
+
+from wagtail_headless_preview.deprecation import (
+    RemovedInWagtailHeadlessPreivew030Warning,
+)
+
+
+DEFAULTS = {
+    "CLIENT_URLS": {},
+    "LIVE_PREVIEW": False,
+    "SERVE_BASE_URL": None,
+    "REDIRECT_ON_PREVIEW": False,
+}
+
+# List of settings that have been deprecated
+DEPRECATED_SETTINGS = [
+    (
+        "HEADLESS_PREVIEW_CLIENT_URLS",
+        "CLIENT_URLS",
+        RemovedInWagtailHeadlessPreivew030Warning,
+    ),
+    (
+        "HEADLESS_PREVIEW_LIVE",
+        "LIVE_PREVIEW",
+        RemovedInWagtailHeadlessPreivew030Warning,
+    ),
+]
+
+# List of settings that have been removed
+REMOVED_SETTINGS = []
+
+
+class WagtailHeadlessPreviewSettings:
+    """
+    A settings object that allows the wagtail_headless_preview settings to be accessed as
+    properties. For example:
+        from wagtail_headless_previews.settings import headless_preview_settings
+        print(headless_preview_settings.CLIENT_URLS)
+    Note:
+    This is an internal class that is only compatible with settings namespaced
+    under the WAGTAIL_HEADLESS_PREVIEW name. It is not intended to be used by 3rd-party
+    apps, and test helpers like `override_settings` may not work as expected.
+    """
+
+    def __init__(self, user_settings=None, defaults=None):
+        if user_settings:
+            self._user_settings = self.__check_user_settings(user_settings)
+        self.defaults = defaults or DEFAULTS
+        self._cached_attrs = set()
+
+    @property
+    def user_settings(self):
+        if not hasattr(self, "_user_settings"):
+            self._user_settings = self.__check_user_settings(
+                getattr(settings, "WAGTAIL_HEADLESS_PREVIEW", {})
+            )
+        return self._user_settings
+
+    def __getattr__(self, attr):
+        if attr not in self.defaults:
+            raise AttributeError(
+                "Invalid wagtail_headless_preview setting: '%s'" % attr
+            )
+
+        try:
+            # Check if present in user settings
+            val = self.user_settings[attr]
+        except KeyError:
+            # Fall back to defaults
+            val = self.defaults[attr]
+
+        # Cache the result
+        self._cached_attrs.add(attr)
+        setattr(self, attr, val)
+        return val
+
+    def __check_user_settings(self, user_settings):
+        for setting, new_setting, category in DEPRECATED_SETTINGS:
+            if setting in user_settings or hasattr(settings, setting):
+                warnings.warn(
+                    f"The '{setting}' setting is deprecated and will be "
+                    f"removed in the next release, use "
+                    f'WAGTAIL_HEADLESS_PREVIEW["{new_setting}"] instead.',
+                    category=category,
+                )
+                user_settings[new_setting] = user_settings[setting]
+        for setting in REMOVED_SETTINGS:
+            if setting in user_settings:
+                raise RuntimeError(
+                    f"The '{setting}' setting has been removed. "
+                    f"Please refer to the wagtail_headless_preview "
+                    f"documentation for available settings."
+                )
+        return user_settings
+
+    def reload(self):
+        for attr in self._cached_attrs:
+            delattr(self, attr)
+        self._cached_attrs.clear()
+        if hasattr(self, "_user_settings"):
+            delattr(self, "_user_settings")
+
+
+headless_preview_settings = WagtailHeadlessPreviewSettings(None, DEFAULTS)
+
+
+def reload_headless_preview_settings(*args, **kwargs):
+    setting = kwargs["setting"]
+    if setting == "WAGTAIL_HEADLESS_PREVIEW":
+        headless_preview_settings.reload()
+
+
+setting_changed.connect(reload_headless_preview_settings)

--- a/wagtail_headless_preview/tests/settings.py
+++ b/wagtail_headless_preview/tests/settings.py
@@ -71,7 +71,7 @@ STATIC_URL = "/static/"
 WAGTAIL_SITE_NAME = "wagtail-headless-preview test"
 BASE_URL = "http://test.local"
 
-HEADLESS_PREVIEW_CLIENT_URLS = {"default": "http://localhost:8020/"}
+WAGTAIL_HEADLESS_PREVIEW = {"CLIENT_URLS": {"default": "http://localhost:8020/"}}
 
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r"^/api/v2/"

--- a/wagtail_headless_preview/tests/test_settings.py
+++ b/wagtail_headless_preview/tests/test_settings.py
@@ -1,0 +1,58 @@
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+
+from wagtail_headless_preview.settings import (
+    WagtailHeadlessPreviewSettings,
+    headless_preview_settings,
+)
+
+
+class SettingsTests(TestCase):
+    def test_compatibility_with_override_settings(self):
+        default_client_urls = {
+            "default": "http://localhost:8020/"
+        }  # set in test app settings
+        self.assertDictEqual(
+            headless_preview_settings.CLIENT_URLS,
+            default_client_urls,
+            "Checking a known default",
+        )
+
+        with override_settings(
+            WAGTAIL_HEADLESS_PREVIEW={
+                "CLIENT_URLS": {"default": "https://headless.site"}
+            }
+        ):
+            self.assertDictEqual(
+                headless_preview_settings.CLIENT_URLS,
+                {"default": "https://headless.site"},
+                "Setting should have been updated",
+            )
+
+        self.assertDictEqual(
+            headless_preview_settings.CLIENT_URLS,
+            default_client_urls,
+            "Setting should have been restored",
+        )
+
+    def test_warning_raised_on_deprecated_setting(self):
+        """
+        Make sure user is alerted with an deprecated setting is used.
+        """
+        msg = (
+            "The 'HEADLESS_PREVIEW_CLIENT_URLS' setting is "
+            "deprecated and will be removed in the next release, "
+            'use WAGTAIL_HEADLESS_PREVIEW["CLIENT_URLS"] instead.'
+        )
+        with self.assertWarnsMessage(PendingDeprecationWarning, msg):
+            WagtailHeadlessPreviewSettings({"HEADLESS_PREVIEW_CLIENT_URLS": {}})
+
+    @patch("wagtail_headless_preview.settings.REMOVED_SETTINGS", ["A_REMOVED_SETTING"])
+    def test_runtime_error_raised_on_removed_setting(self):
+        msg = (
+            "The 'A_REMOVED_SETTING' setting has been removed. "
+            "Please refer to the wagtail_headless_preview documentation for available settings."
+        )
+        with self.assertRaisesMessage(RuntimeError, msg):
+            WagtailHeadlessPreviewSettings({"A_REMOVED_SETTING": "something"})

--- a/wagtail_headless_preview/wagtail_hooks.py
+++ b/wagtail_headless_preview/wagtail_hooks.py
@@ -3,16 +3,18 @@ from django.utils.html import format_html_join
 
 from wagtail.core import hooks
 
+from wagtail_headless_preview.settings import headless_preview_settings
+
 
 @hooks.register("insert_editor_js")
 def editor_js():
-    if hasattr(settings, "HEADLESS_PREVIEW_LIVE") and settings.HEADLESS_PREVIEW_LIVE:
-        js_files = ["js/live-preview.js"]
+    if not headless_preview_settings.LIVE_PREVIEW:
+        return ""
 
-        return format_html_join(
-            "\n",
-            '<script src="{0}{1}"></script>',
-            ((settings.STATIC_URL, filename) for filename in js_files),
-        )
+    js_files = ["js/live-preview.js"]
 
-    return ""
+    return format_html_join(
+        "\n",
+        '<script src="{0}{1}"></script>',
+        ((settings.STATIC_URL, filename) for filename in js_files),
+    )


### PR DESCRIPTION
This PR moves the various disparate settings to a single, namespaced settings dict

```python
WAGTAIL_HEADLESS_PREVIEW = {
    "CLIENT_URLS": {},  # defaults to an empty dict. You must at the very least define the default client URL.
    "LIVE_PREVIEW": False,  # set to True to enable live preview functionality
    "SERVE_BASE_URL": None,  # can be used for HeadlessServeMixin
    "REDIRECT_ON_PREVIEW": False,  # set to True to redirect to the preview instead of using the Wagtail default mechanism
}
```