### PR TITLE
wagtail 3.0 import compatability

### DIFF
--- a/src/wagtail_headless_preview/wagtail_hooks.py
+++ b/src/wagtail_headless_preview/wagtail_hooks.py
@@ -1,7 +1,11 @@
 from django.conf import settings
 from django.utils.html import format_html_join
 
-from wagtail.core import hooks
+# Ensure backwards compatability < 3.0
+try:
+    from wagtail import hooks
+except ImportError:
+    from wagtail.core import hooks
 
 from wagtail_headless_preview.settings import headless_preview_settings
 


### PR DESCRIPTION
Perhaps a bit too early to update headless preview for 3.0 compatability. But this is what I noticed needed a change when using the release candidate.