### PR TITLE
Support Wagtail3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Add support for Wagtail 3.0.
 
 ## [0.2.1] - 2022-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
-- Add support for Wagtail 3.0.
+ - Add support for Wagtail 3.0 and drop support for all Wagtail versions
+   before 2.15
+   
+ - Removed support for Django 2.2
 
 ## [0.2.1] - 2022-02-01
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     license="BSD",
-    install_requires=["wagtail>=2.11"],
+    install_requires=["wagtail>=2.15"],
     extras_require={"testing": ["tox", "django-cors-headers"]},
     keywords=["wagtail", "django", "headless"],
     classifiers=[
@@ -45,7 +45,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Framework :: Wagtail",

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "Framework :: Django :: 4.0",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
+        "Framework :: Wagtail :: 3",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],

--- a/src/wagtail_headless_preview/wagtail_hooks.py
+++ b/src/wagtail_headless_preview/wagtail_hooks.py
@@ -1,7 +1,12 @@
 from django.conf import settings
 from django.utils.html import format_html_join
 
-from wagtail.core import hooks
+
+try:
+    from wagtail import hooks
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core import hooks
 
 from wagtail_headless_preview.settings import headless_preview_settings
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,7 @@
 import os
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
 
 DEBUG = "INTERACTIVE" in os.environ
 
@@ -15,7 +17,7 @@ INSTALLED_APPS = [
     "wagtail.images",
     "wagtail.documents",
     "wagtail.admin",
-    "wagtail.core",
+    "wagtail" if WAGTAIL_VERSION >= (3, 0) else "wagtail.core",
     "wagtail.api.v2",
     "taggit",
     "django.contrib.auth",

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -3,7 +3,12 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
 
-from wagtail.core.models import Page
+
+try:
+    from wagtail.models import Page
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core.models import Page
 
 from tests.testapp.models import HeadlessPage, SimplePage
 from wagtail_headless_preview.models import PagePreview

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,4 +1,7 @@
-from wagtail.core.models import Page
+try:
+    from wagtail.models import Page
+except ImportError:
+    from wagtail.core.models import Page
 
 from wagtail_headless_preview.models import HeadlessMixin, HeadlessPreviewMixin
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,7 +4,12 @@ from django.conf.urls import include
 from django.urls import path
 
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
+
+
+try:
+    from wagtail import urls as wagtail_urls
+except ImportError:
+    from wagtail.core import urls as wagtail_urls
 
 from tests.testapp.api import api_router
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -9,6 +9,7 @@ from wagtail.admin import urls as wagtailadmin_urls
 try:
     from wagtail import urls as wagtail_urls
 except ImportError:
+    # Wagtail<3.0
     from wagtail.core import urls as wagtail_urls
 
 from tests.testapp.api import api_router

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ requires = tox >= 3.23.0, < 4.0
 
 # note: use py and non-dotted python version as we use tox-py
 envlist =
-    py{38,39,310}-django{2.2}-wagtail{2.13}
-    py{38,39,310}-django{3.2}-wagtail{2.15,2.16}
-    py{310}-django{4.0}-wagtail{2.16,main}
+    py{38,39,310}-django{3.2}-wagtail{2.15,2.16,3.0}
+    py{38,39,310}-django{4.0}-wagtail{2.16,3.0}
+    py{310}-django{4.0}-wagtail{3.0,main}
 
 [testenv]
 setenv =
@@ -18,15 +18,14 @@ extras = testing
 
 deps =
     coverage
-
-    django2.2: Django~=2.2
+    
     django3.2: Django~=3.2
     django4.0: Django~=4.0
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
-    wagtail2.14: wagtail~=2.13
-    wagtail2.15: wagtail~=2.15
-    wagtail2.16: wagtail>=2.16rc2,<2.17
+    wagtail2.15: wagtail>=2.15,<2.16
+    wagtail2.16: wagtail>=2.16,<2.17
+    wagtail3.0: wagtail>=3.0,<4.0
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=wagtail
 
 install_command = pip install -U {opts} {packages}


### PR DESCRIPTION
[Ticket
](https://projects.torchbox.com/projects/support-team/tickets/493)

Make the current package support Wagtail 3.0. 

- Drop Django 2.2 (EOL)
- Drop Wagtail 2.11 (EOL), 2.13 (EOL), 2.14 (EOL)
- Add Wagtail 3.0 support
