### PR TITLE
Make Wagtail 5.1 support official

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add Wagtail 5.1 support
+- Make Wagtail 5.1 support official
 
 ## [0.6] - 2023-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add Wagtail 5.1 support
+
 ## [0.6] - 2023-06-08
 
 - Add Wagtail 4.2 support and drop support for Wagtail < 4.1

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ requires = tox >= 3.23.0, < 4.0
 
 # note: use py and non-dotted python version as we use tox-py
 envlist =
-    py{38,39,310}-django{3.2,4.1}-wagtail{4.1,4.2,5.0,5.1}
-    py{311}-django{4.1}-wagtail{4.1,4.2,5.0,5.1}
+    py{38,39,310}-django{3.2,4.1}-wagtail{4.2,5.0,5.1}
+    py{311}-django{4.1}-wagtail{4.2,5.0,5.1}
     py{311}-django{4.2}-wagtail{5.0,5.1}
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ requires = tox >= 3.23.0, < 4.0
 
 # note: use py and non-dotted python version as we use tox-py
 envlist =
-    py{38,39,310}-django{3.2,4.1}-wagtail{4.1,4.2,5.0}
-    py{311}-django{4.1}-wagtail{4.1,4.2,5.0}
-    py{311}-django{4.2}-wagtail{5.0}
+    py{38,39,310}-django{3.2,4.1}-wagtail{4.1,4.2,5.0,5.1}
+    py{311}-django{4.1}-wagtail{4.1,4.2,5.0,5.1}
+    py{311}-django{4.2}-wagtail{5.0,5.1}
 
 [testenv]
 setenv =
@@ -26,6 +26,7 @@ deps =
     wagtail4.1: wagtail>=4.1, <4.2
     wagtail4.2: wagtail>=4.2, <5.0
     wagtail5.0: wagtail>=5.0, <5.1
+    wagtail5.1: wagtail>=5.1, <5.2
 
 install_command = pip install -U {opts} {packages}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ requires = tox >= 3.23.0, < 4.0
 
 # note: use py and non-dotted python version as we use tox-py
 envlist =
-    py{38,39,310}-django{3.2,4.1}-wagtail{4.2,5.0,5.1}
-    py{311}-django{4.1}-wagtail{4.2,5.0,5.1}
+    py{38,39,310}-django{3.2,4.1}-wagtail{4.1,5.0,5.1}
+    py{311}-django{4.1}-wagtail{4.1,5.0,5.1}
     py{311}-django{4.2}-wagtail{5.0,5.1}
 
 [testenv]


### PR DESCRIPTION
- Update testing matrix to explicitly support Wagtail 5.1