### PR TITLE
Update API view endpoint in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ class PagePreviewAPIViewSet(PagesAPIViewSet):
     def listing_view(self, request):
         # Delegate to detail_view, specifically so there's no
         # difference between serialization formats.
-        self.action = 'detail_view'
+        self.action = "detail_view"
         return self.detail_view(request, 0)
 
     def detail_view(self, request, pk):

--- a/README.md
+++ b/README.md
@@ -197,9 +197,10 @@ class PagePreviewAPIViewSet(PagesAPIViewSet):
     )
 
     def listing_view(self, request):
-        page = self.get_object()
-        serializer = self.get_serializer(page)
-        return Response(serializer.data)
+        # Delegate to detail_view, specifically so there's no
+        # difference between serialization formats.
+        self.action = 'detail_view'
+        return self.detail_view(request, 0)
 
     def detail_view(self, request, pk):
         page = self.get_object()


### PR DESCRIPTION
Provided example exports different fields for detail_view and listing_view. It's easy to work around this on frontend (just add a /0/ to the URL), but it looks wrong and the consistency fix makes it clearer what listing_view tries to do.