### PR TITLE
Make `get_client_root_url` overridable both in both mixins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.2.1'
+    rev: 'v0.2.2'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import User
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
 from wagtail.models import Page
@@ -29,6 +29,8 @@ class TestFrontendViews(TestCase):
 
         cls.page.title = "Simple page with draft edit"
         cls.page.save_revision()
+
+        cls.request = RequestFactory().get("/")
 
     def setUp(self):
         self.client.login(username=self.admin_user.username, password="password")
@@ -77,7 +79,7 @@ class TestFrontendViews(TestCase):
 
         self.assertRedirects(
             response,
-            self.page.get_preview_url(preview_token),
+            self.page.get_preview_url(self.request, preview_token),
             fetch_redirect_response=False,
         )
 
@@ -86,7 +88,7 @@ class TestFrontendViews(TestCase):
     )
     def test_get_client_root_url_with_default_trailing_slash_enforcement(self):
         self.assertEqual(
-            self.page.get_client_root_url(),
+            self.page.get_client_root_url(self.request),
             "https://headless.site/",
         )
 
@@ -98,7 +100,7 @@ class TestFrontendViews(TestCase):
     )
     def test_get_client_root_url_without_trailing_slash_enforcement(self):
         self.assertEqual(
-            self.page.get_client_root_url(),
+            self.page.get_client_root_url(self.request),
             "https://headless.site",
         )
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,6 +1,13 @@
+from typing import TYPE_CHECKING
+
+from django.conf import settings
 from wagtail.models import Page
 
 from wagtail_headless_preview.models import HeadlessMixin, HeadlessPreviewMixin
+
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
 
 
 class SimplePage(HeadlessPreviewMixin, Page):
@@ -8,4 +15,8 @@ class SimplePage(HeadlessPreviewMixin, Page):
 
 
 class HeadlessPage(HeadlessMixin, Page):
-    pass
+    def get_client_root_url(self, request: "HttpRequest") -> str:
+        if getattr(settings, "TEST_OVERRIDE_CLIENT_ROOT_URL", False):
+            return "https://wagtail.org"
+
+        return super().get_client_root_url(request)


### PR DESCRIPTION
To-Do:

- [x] tests (a simple page inheriting from both mixins)
- [ ] upgrade considerations for release notes