### PR TITLE
Wagtail 6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
     "Topic :: Internet :: WWW/HTTP",
@@ -32,7 +30,7 @@ classifiers = [
 
 dynamic = ["version"]
 requires-python = ">=3.8"
-dependencies = ["Wagtail>=4.1"]
+dependencies = ["Wagtail>=5.2"]
 
 [project.optional-dependencies]
 testing = [

--- a/src/wagtail_headless_preview/settings.py
+++ b/src/wagtail_headless_preview/settings.py
@@ -58,9 +58,7 @@ class WagtailHeadlessPreviewSettings:
 
     def __getattr__(self, attr):
         if attr not in self.defaults:
-            raise AttributeError(
-                "Invalid wagtail_headless_preview setting: '%s'" % attr
-            )
+            raise AttributeError(f"Invalid wagtail_headless_preview setting: '{attr}'")
 
         try:
             # Check if present in user settings

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 min_version =  4.11
 
 env_list =
-    python{3.8,3.9,3.10}-django3.2-wagtail5.2
-    python{3.8,3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0}
-    python{3.11,3.12}-django5.0-wagtail{5.2,6.0}
+    python{3.8,3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1}
 
 [gh-actions]
 python =
@@ -32,7 +31,6 @@ set_env =
 extras = testing
 
 deps =
-    django3.2: Django>=3.2, <4.0
     django4.2: Django>=4.2, <5.0
     django5.0: Django>=5.0, <5.1
 


### PR DESCRIPTION
# Notes

- No significant changes related to Wagtail 6.1
- Drop support for Django < 4.2 as those have reached EOL
