### PR TITLE
Update testing for Wagtail 6.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           cache: "pip"
           cache-dependency-path: "**/pyproject.toml"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ env:
   TOX_TESTENV_PASSENV: FORCE_COLOR
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PIP_NO_PYTHON_VERSION_WARNING: "1"
-  PYTHON_LATEST: "3.12"
+  PYTHON_LATEST: "3.13"
 
 jobs:
   tests:
@@ -67,6 +67,7 @@ jobs:
         name: coverage-data-${{ matrix.python-version }}
         path: .coverage.*
         if-no-files-found: ignore
+        include-hidden-files: true
         retention-days: 1
 
   coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add tox testing for Django 5.1 and Wagtail 6.2 + 6.3
-- Drop testing for python 3.8
+- Drop testing for Python 3.8
 
 ## [0.8] - 2024-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add tox testing for Django 5.1 and Wagtail 6.2 + 6.3
+- Drop testing for python 3.8
+
 ## [0.8] - 2024-02-23
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -21,6 +20,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dynamic = ["version"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["Wagtail>=5.2"]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 min_version =  4.11
 
 env_list =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2,6.3}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1,6.2,6.3}
+    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.2,6.3}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.2,6.3}
     python{3.10,3.11,3.12}-django5.1-wagtail6.3
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ min_version =  4.11
 env_list =
     python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.2,6.3}
     python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.2,6.3}
-    python{3.10,3.11,3.12}-django5.1-wagtail6.3
+    python{3.10,3.11,3.12,3.13}-django5.1-wagtail6.3
 
 [gh-actions]
 python =
@@ -12,6 +12,7 @@ python =
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12
+    3.13: python3.13
 
 [testenv]
 package = wheel
@@ -44,7 +45,7 @@ commands =
     python -Im coverage run runtests.py test --deprecation all {posargs: -v 2}
 
 [testenv:coverage-report]
-base_python = python3.12
+base_python = python3.13
 package = skip
 deps =
     coverage>=7.0,<8.0
@@ -54,14 +55,14 @@ commands =
 
 [testenv:wagtailmain]
 description = Test with latest Wagtail main branch
-base_python = python3.12
+base_python = python3.13
 deps =
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 [testenv:interactive]
 package = editable
 description = An interactive environment for local testing purposes
-base_python = python3.12
+base_python = python3.13
 
 commands_pre =
     python {toxinidir}/manage.py makemigrations

--- a/tox.ini
+++ b/tox.ini
@@ -36,9 +36,8 @@ deps =
     django5.1: Django>=5.1, <5.2
 
     wagtail5.2: wagtail>=5.2, <6.0
-    wagtail6.0: wagtail>=6.0, <6.1
-    wagtail6.1: wagtail>=6.1, <6.2
     wagtail6.2: wagtail>=6.2, <6.3
+    wagtail6.3: wagtail>=6.3, <6.4
 
 install_command = python -Im pip install -U {opts} {packages}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,11 @@
 min_version =  4.11
 
 env_list =
-    python{3.8,3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1}
+    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2,6.3}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1,6.2,6.3}
 
 [gh-actions]
 python =
-    3.8: python3.8
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
@@ -36,6 +35,8 @@ deps =
 
     wagtail5.2: wagtail>=5.2, <6.0
     wagtail6.0: wagtail>=6.0, <6.1
+    wagtail6.1: wagtail>=6.1, <6.2
+    wagtail6.2: wagtail>=6.2, <6.3
 
 install_command = python -Im pip install -U {opts} {packages}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ min_version =  4.11
 env_list =
     python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2,6.3}
     python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1,6.2,6.3}
+    python{3.10,3.11,3.12}-django5.1-wagtail6.3
 
 [gh-actions]
 python =
@@ -32,6 +33,7 @@ extras = testing
 deps =
     django4.2: Django>=4.2, <5.0
     django5.0: Django>=5.0, <5.1
+    django5.1: Django>=5.1, <5.2
 
     wagtail5.2: wagtail>=5.2, <6.0
     wagtail6.0: wagtail>=6.0, <6.1

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ min_version =  4.11
 env_list =
     python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.2,6.3}
     python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.2,6.3}
-    python{3.10,3.11,3.12,3.13}-django5.1-wagtail6.3
+    python{3.12,3.13}-django5.1-wagtail6.3
 
 [gh-actions]
 python =


### PR DESCRIPTION
# Update testing for Wagtail 6.3

When merged this will:

- Update the tox testing to include Wagtail 6.2 & 6.3
- Add Django 5.1 to the testing matrix
- Update the project metadata accordingly
- Drop testing for python 3.8