### PR TITLE
Fix `get_client_root_url` when no Site is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add tox testing for Django 5.1 and Wagtail 6.2 + 6.3
 - Drop testing for Python 3.8
+- Fix `get_client_root_url` when no Site is set
 
 ## [0.8] - 2024-02-23
 

--- a/src/wagtail_headless_preview/models.py
+++ b/src/wagtail_headless_preview/models.py
@@ -50,7 +50,7 @@ def get_client_root_url_from_site(site) -> str:
         root_url = headless_preview_settings.CLIENT_URLS[site.hostname]
     except (AttributeError, KeyError):
         root_url = headless_preview_settings.CLIENT_URLS["default"].format(
-            SITE_ROOT_URL=site.root_url
+            SITE_ROOT_URL=getattr(site, "root_url", "")
         )
 
     if headless_preview_settings.ENFORCE_TRAILING_SLASH:

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
-from wagtail.models import Page
+from wagtail.models import Page, Site
 
 from tests.testapp.models import HeadlessPage, SimplePage
 from wagtail_headless_preview.models import PagePreview
@@ -107,6 +107,18 @@ class TestMixins(TestCase):
         self.assertEqual(
             self.page.get_client_root_url(self.request),
             "https://headless.site",
+        )
+
+    @override_settings(
+        WAGTAIL_HEADLESS_PREVIEW={
+            "CLIENT_URLS": {"default": "https://headless.site"},
+        }
+    )
+    def test_get_client_root_url_with_no_site(self):
+        Site.objects.all().delete()
+        self.assertEqual(
+            self.page.get_client_root_url(self.request),
+            "https://headless.site/",
         )
 
     @override_settings(


### PR DESCRIPTION
fixes #69