### PR TITLE
Update tox matrix for Wagtail 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add tox testing for Django 5.1 and Wagtail 6.3
-- Drop testing for Python 3.8
+- Add tox testing for Wagtail 6.3, 6.4 and 7.0, Django 5.1, 5.2
+- Drop testing for Wagtail 5.2, Django 5.0, Python 3.8
 
 ## [0.8] - 2024-02-23
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version =  4.11
 
 env_list =
-    python{3.9,3.10,3.11}-django4.2-wagtail{6.3,6.4}
+    python{3.9,3.10,3.11}-django4.2-wagtail{6.3,6.4,7.0}
     python{3.10,3.11,3.12}-django5.0-wagtail{6.3,6.4}
-    python{3.12,3.13}-django5.1-wagtail{6.3,6.4}
+    python{3.12,3.13}-django5.1-wagtail{6.3,6.4,7.0}
 
 [gh-actions]
 python =
@@ -35,7 +35,7 @@ deps =
     django4.2: Django>=4.2, <5.0
     django5.0: Django>=5.0, <5.1
     django5.1: Django>=5.1, <5.2
-
+    wagtail7.0: wagtail>=7.0, <7.1
     wagtail6.3: wagtail>=6.3, <6.4
     wagtail6.4: wagtail>=6.4, <6.5
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 min_version =  4.11
 
 env_list =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.3,6.4}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.3,6.4}
+    python{3.9,3.10,3.11}-django4.2-wagtail{6.3,6.4}
+    python{3.10,3.11,3.12}-django5.0-wagtail{6.3,6.4}
     python{3.12,3.13}-django5.1-wagtail{6.3,6.4}
 
 [gh-actions]
@@ -36,7 +36,6 @@ deps =
     django5.0: Django>=5.0, <5.1
     django5.1: Django>=5.1, <5.2
 
-    wagtail5.2: wagtail>=5.2, <6.0
     wagtail6.3: wagtail>=6.3, <6.4
     wagtail6.4: wagtail>=6.4, <6.5
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ min_version =  4.11
 
 env_list =
     python{3.9,3.10,3.11}-django4.2-wagtail{6.3,6.4,7.0}
-    python{3.10,3.11,3.12}-django5.0-wagtail{6.3,6.4}
     python{3.12,3.13}-django5.1-wagtail{6.3,6.4,7.0}
+    python{3.10,3.11,3.12,3.13}-django5.2-wagtail{6.3,6.4,7.0}
 
 [gh-actions]
 python =
@@ -33,11 +33,11 @@ extras = testing
 
 deps =
     django4.2: Django>=4.2, <5.0
-    django5.0: Django>=5.0, <5.1
     django5.1: Django>=5.1, <5.2
-    wagtail7.0: wagtail>=7.0, <7.1
+    django5.2: Django>=5.2, <5.3
     wagtail6.3: wagtail>=6.3, <6.4
     wagtail6.4: wagtail>=6.4, <6.5
+    wagtail7.0: wagtail>=7.0, <7.1
 
 install_command = python -Im pip install -U {opts} {packages}
 commands =


### PR DESCRIPTION
When applied, this MR will bring the tox testing matrix up to date with supported versions of Wagtail and Django.