### PR TITLE
Wagtail 71 maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Wagtail 7.0 and 7.1 upgrade changes:
+
+- Add tox testing for Django 5.2 and Wagtail 7.0, 7.1
+- Drop testing for Django 5.0
+- Drop testing for Wagtail 5.2 and 6.4
+
+Wagtail 6.3 upgrade changes:
+
 - Add tox testing for Django 5.1 and Wagtail 6.3
 - Drop testing for Python 3.8
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,18 +20,18 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
 
 dynamic = ["version"]
 requires-python = ">=3.9"
-dependencies = ["Wagtail>=5.2"]
+dependencies = ["Wagtail>=6.3"]
 
 [project.optional-dependencies]
 testing = [

--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 import argparse
 import os
 import sys
@@ -7,6 +8,8 @@ import warnings
 from django.core.management import execute_from_command_line
 
 
+# Ensure the tests directory is in sys.path for Django import
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 os.environ["DJANGO_SETTINGS_MODULE"] = "tests.settings"
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 min_version =  4.11
 
 env_list =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.3,6.4}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.3,6.4}
-    python{3.12,3.13}-django5.1-wagtail{6.3,6.4}
+    python{3.9}-django4.2-wagtail{6.3,7.0,7.1}
+    python{3.10,3.11,3.12,3.13}-django{5.1,5.2}-wagtail{6.3,7.0,7.1}
 
 [gh-actions]
 python =
@@ -33,12 +32,12 @@ extras = testing
 
 deps =
     django4.2: Django>=4.2, <5.0
-    django5.0: Django>=5.0, <5.1
     django5.1: Django>=5.1, <5.2
+    django5.2: Django>=5.2, <5.3
 
-    wagtail5.2: wagtail>=5.2, <6.0
     wagtail6.3: wagtail>=6.3, <6.4
-    wagtail6.4: wagtail>=6.4, <6.5
+    wagtail7.0: wagtail>=7.0, <7.1
+    wagtail7.1: wagtail>=7.1, <7.2
 
 install_command = python -Im pip install -U {opts} {packages}
 commands =


### PR DESCRIPTION
This pull request updates the project's compatibility and testing matrix to support newer versions of Django and Wagtail.

**Dependency and Testing Matrix Updates:**

* Updated `tox.ini` to add testing environments for Django 5.2 and Wagtail 7.0/7.1, and removed environments for Django 5.0, Wagtail 5.2, and Wagtail 6.4.
* Updated dependency requirements in `pyproject.toml` to require Wagtail >=6.3 and added classifiers for Django 5.2 and Wagtail 7, while removing Django 5.0 and Wagtail 5 classifiers.
* Updated the changelog in `CHANGELOG.md` to reflect the new testing matrix and dropped support for older versions.
* Updated dependency installation and environment definitions in `tox.ini` for Django 5.2 and Wagtail 7.0/7.1.

**Test Runner Improvements:**

* Modified `runtests.py` to ensure the tests directory is in `sys.path` for proper Django imports.